### PR TITLE
Remove double ternary operator

### DIFF
--- a/functions/abus-core-functions.php
+++ b/functions/abus-core-functions.php
@@ -11,7 +11,7 @@ defined('ABSPATH') || exit;
  */
 function abus_get_current_url($parse = false )
 {
-    $s = empty( $_SERVER[ 'HTTPS' ] ) ? '' : ( $_SERVER[ 'HTTPS' ] == 'on' ) ? 's' : '';
+    $s = empty( $_SERVER[ 'HTTPS' ] ) || ( $_SERVER[ 'HTTPS' ] != 'on' ) ? '' : 's';
     $protocol = substr( strtolower( $_SERVER[ 'SERVER_PROTOCOL' ] ), 0, strpos( strtolower( $_SERVER[ 'SERVER_PROTOCOL' ] ), '/' ) ) . $s;
     $port = ( $_SERVER[ 'SERVER_PORT' ] == '80') ? '' : ( ":".$_SERVER[ 'SERVER_PORT' ] );
 

--- a/includes/Controllers/AdminBar.php
+++ b/includes/Controllers/AdminBar.php
@@ -64,7 +64,7 @@ class AdminBar
                     $link = add_query_arg( 'redirect_to', apply_filters( 'abus_switch_to_url', $url ), $link );
                     $html .= '
                         <p class="result">
-                            <a href="' . esc_url( $link, $user ) . '">' . $user->display_name . '</a>
+                            <a href="' . esc_url( $link, $user ) . '">' . apply_filters( 'abus_display_name', $user->display_name, $user ) . '</a>
                         </p>
                     ';
                 }


### PR DESCRIPTION
Resolves drazenbebic/admin-bar-user-switching#2

https://wiki.php.net/rfc/ternary_associativity
Left-associative ternary operators are deprecated and trigger warnings under PHP7.