### PR TITLE
Remove double ternary operator

### DIFF
--- a/functions/abus-core-functions.php
+++ b/functions/abus-core-functions.php
@@ -11,7 +11,7 @@ defined('ABSPATH') || exit;
  */
 function abus_get_current_url($parse = false )
 {
-    $s = empty( $_SERVER[ 'HTTPS' ] ) ? '' : ( $_SERVER[ 'HTTPS' ] == 'on' ) ? 's' : '';
+    $s = empty( $_SERVER[ 'HTTPS' ] ) || ( $_SERVER[ 'HTTPS' ] != 'on' ) ? '' : 's';
     $protocol = substr( strtolower( $_SERVER[ 'SERVER_PROTOCOL' ] ), 0, strpos( strtolower( $_SERVER[ 'SERVER_PROTOCOL' ] ), '/' ) ) . $s;
     $port = ( $_SERVER[ 'SERVER_PORT' ] == '80') ? '' : ( ":".$_SERVER[ 'SERVER_PORT' ] );
 


### PR DESCRIPTION
Resolves #2

https://wiki.php.net/rfc/ternary_associativity
Left-associative ternary operators are deprecated and trigger warnings under PHP7.

