### PR TITLE
Fix deprecated statement, simplify code

### DIFF
--- a/functions/abus-core-functions.php
+++ b/functions/abus-core-functions.php
@@ -11,13 +11,13 @@ defined('ABSPATH') || exit;
  */
 function abus_get_current_url($parse = false )
 {
-    $s = empty( $_SERVER[ 'HTTPS' ] ) || ( $_SERVER[ 'HTTPS' ] != 'on' ) ? '' : 's';
-    $protocol = substr( strtolower( $_SERVER[ 'SERVER_PROTOCOL' ] ), 0, strpos( strtolower( $_SERVER[ 'SERVER_PROTOCOL' ] ), '/' ) ) . $s;
     $port = ( $_SERVER[ 'SERVER_PORT' ] == '80') ? '' : ( ":".$_SERVER[ 'SERVER_PORT' ] );
 
+    $url = set_url_scheme( 'https://' . $_SERVER[ 'HTTP_HOST' ] . $port . $_SERVER[ 'REQUEST_URI' ] );
+    
     if ( $parse ) {
-        return parse_url( $protocol . "://" . $_SERVER[ 'HTTP_HOST' ] . $port . $_SERVER[ 'REQUEST_URI' ] );
+        return parse_url( $url );
     }
 
-    return apply_filters('abus_get_current_url', $protocol . "://" . $_SERVER[ 'HTTP_HOST' ] . $port . $_SERVER[ 'REQUEST_URI' ]);
+    return apply_filters('abus_get_current_url', $url );
 }


### PR DESCRIPTION
### Deprecated statement

See threads about deprecated code here: 

https://wordpress.org/support/topic/deprecated-feature/
https://wordpress.org/support/topic/update-pluggin-deprecated-coce/

```
Deprecated: Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)` in […]/plugins/admin-bar-user-switching/functions/abus-core-functions.php on line 14
```

### Simplify code

The code WordPress uses in `WP_List_Table::pagination()` is:

```
$current_url = set_url_scheme( 'http://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] );
```

I'd prefer to just use `add_query_arg( array() );` but don't know the back-story of why the code currently is how it is.